### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-
+ACLOCAL_AMFLAGS=-I m4
 
 nobase_include_HEADERS = sonic/db_sql_defines.h  sonic/db_sql_ops.h
 #The sdi-sys library

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_INIT([sonic-db-sql], [1.0.1], [sonicproject@gmail.com])
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIRS([m4])
 
 # Checks for programs.
 AC_PROG_CXX


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.